### PR TITLE
Set default value for credentials_file_path

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,4 +34,3 @@ module "secret" {
   bucket = local.bucket_name
   path   = local.object_path
 }
-

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@
   Provider configuration
  *****************************************/
 provider "google" {
-  credentials = file(var.credentials_file_path)
+  credentials = var.credentials_file_path == null ? null : file(var.credentials_file_path)
 }
 
 locals {

--- a/main.tf
+++ b/main.tf
@@ -18,19 +18,20 @@
   Provider configuration
  *****************************************/
 provider "google" {
-  credentials = "${file(var.credentials_file_path)}"
+  credentials = file(var.credentials_file_path)
 }
 
 locals {
   //  secret_project = "${var.project_name}"
   shared_bucket = "shared-${var.env}-secrets"
   app_bucket    = "${var.application_name}-${var.env}-secrets"
-  bucket_name   = "${var.shared == "true" ? local.shared_bucket : local.app_bucket}"
+  bucket_name   = var.shared == "true" ? local.shared_bucket : local.app_bucket
   object_path   = "${var.secret}.txt"
 }
 
 module "secret" {
   source = "./modules/gcs-object"
-  bucket = "${local.bucket_name}"
-  path   = "${local.object_path}"
+  bucket = local.bucket_name
+  path   = local.object_path
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -16,5 +16,6 @@
 
 output "contents" {
   description = "The actual value of the requested secret"
-  value       = "${module.secret.contents}"
+  value       = module.secret.contents
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,4 +18,3 @@ output "contents" {
   description = "The actual value of the requested secret"
   value       = module.secret.contents
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,7 @@ variable "secret" {
 
 variable "shared" {
   description = "Will we fetch the secret from the shared bucket instead of an application-specific bucket?"
-  type        = "string"
+  type        = string
   default     = "false"
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,7 @@
 
 variable "credentials_file_path" {
   description = "The path to the GCP credentials"
+  default = null
 }
 
 variable "application_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -35,4 +35,3 @@ variable "shared" {
   type        = string
   default     = "false"
 }
-

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 0.12"
 }


### PR DESCRIPTION
This fixes #4 by defaulting `credentials_file_path` to `null` and leaving `credentials` unset if `credentials_file_path` is unset. This does require upgrading to Terraform 0.12 though.